### PR TITLE
Tests: Make tests Python 3 compatible

### DIFF
--- a/tests/all-errors-documented.py
+++ b/tests/all-errors-documented.py
@@ -24,7 +24,7 @@ def check_all_errors_documented(abs_top_srcdir):
                 error.getAttribute('name').replace('.', '_').replace(' ', '_').upper())
 
         if '%s\n' % name not in sections:
-            print "'%s' is missing in %s" % (name, sections_path)
+            print("'%s' is missing in %s" % (name, sections_path))
             sys.exit(1)
 
 if __name__ == '__main__':


### PR DESCRIPTION
all-errors-documented.py is not python 3 compatible because of this print statement.
